### PR TITLE
ADSR Envelope + Voice struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,9 +684,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "syn"

--- a/audio_backend/src/devices/streams.rs
+++ b/audio_backend/src/devices/streams.rs
@@ -4,11 +4,10 @@ use cpal::traits::{HostTrait, StreamTrait};
 use cpal::Stream;
 use cpal::{traits::DeviceTrait, FromSample, Sample};
 
-use crate::synths::oscillator::{Oscillator, Saw, Sine, Square, Triangle};
-use crate::synths::synthesizer::{ActiveWaveform, SynthControl, Synthesizer};
+use crate::synths::synthesizer::{Synthesizer, Voice}; // Import Voice
 
 // This function sets up and runs the CPAL audio stream.
-// It takes the synthesizer control state as input.
+// It takes the synthesizer as input.
 // It returns the Stream object, which must be kept alive for audio to play.
 pub fn run_audio_engine(synth: Arc<Synthesizer>) -> anyhow::Result<Stream> {
     // --- CPAL Setup ---
@@ -25,24 +24,14 @@ pub fn run_audio_engine(synth: Arc<Synthesizer>) -> anyhow::Result<Stream> {
     let err_fn = |err| eprintln!("An error occurred on the output audio stream: {}", err);
     let sample_format = supported_config.sample_format();
     let config: cpal::StreamConfig = supported_config.into();
-    let sample_rate = config.sample_rate.0 as f32;
+    // let sample_rate = config.sample_rate.0 as f32; // Sample rate is now managed by Synthesizer/Voice
     let channels = config.channels as usize;
 
     println!("Using device: {}", device.name()?);
     println!("Using config: {:?}", config);
 
-    // --- Oscillator Initialization (Local to the audio thread closure) ---
-    let mut sine_osc = Oscillator::<Sine>::new(sample_rate, 0.0);
-    let mut square_osc = Oscillator::<Square>::new(sample_rate, 0.0);
-    let mut saw_osc = Oscillator::<Saw>::new(sample_rate, 0.0);
-    let mut triangle_osc = Oscillator::<Triangle>::new(sample_rate, 0.0);
-
-    // Clone the control Arc for the audio thread
-    let control_clone = synth.get_control_clone();
-
-    // --- State for the Audio Callback ---
-    // We need to track the previously active waveform to detect changes.
-    let mut previous_waveform = synth.get_initial_waveform(); // Initialize with starting waveform
+    // Get the thread-safe handle to the voice
+    let voice_handle = synth.get_voice_handle(); // Use the new method
 
     // --- Build and Play Stream ---
     println!("Attempting to build stream...");
@@ -50,17 +39,8 @@ pub fn run_audio_engine(synth: Arc<Synthesizer>) -> anyhow::Result<Stream> {
         cpal::SampleFormat::F32 => device.build_output_stream(
             &config,
             move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
-                // Pass mutable reference to previous_waveform state
-                write_data(
-                    data,
-                    channels,
-                    &control_clone,
-                    &mut sine_osc,
-                    &mut square_osc,
-                    &mut saw_osc,
-                    &mut triangle_osc,
-                    &mut previous_waveform,
-                );
+                // Pass only the voice handle
+                write_data(data, channels, &voice_handle);
             },
             err_fn,
             None,
@@ -68,16 +48,7 @@ pub fn run_audio_engine(synth: Arc<Synthesizer>) -> anyhow::Result<Stream> {
         cpal::SampleFormat::I16 => device.build_output_stream(
             &config,
             move |data: &mut [i16], _: &cpal::OutputCallbackInfo| {
-                write_data(
-                    data,
-                    channels,
-                    &control_clone,
-                    &mut sine_osc,
-                    &mut square_osc,
-                    &mut saw_osc,
-                    &mut triangle_osc,
-                    &mut previous_waveform,
-                );
+                write_data(data, channels, &voice_handle);
             },
             err_fn,
             None,
@@ -85,16 +56,7 @@ pub fn run_audio_engine(synth: Arc<Synthesizer>) -> anyhow::Result<Stream> {
         cpal::SampleFormat::U16 => device.build_output_stream(
             &config,
             move |data: &mut [u16], _: &cpal::OutputCallbackInfo| {
-                write_data(
-                    data,
-                    channels,
-                    &control_clone,
-                    &mut sine_osc,
-                    &mut square_osc,
-                    &mut saw_osc,
-                    &mut triangle_osc,
-                    &mut previous_waveform,
-                );
+                write_data(data, channels, &voice_handle);
             },
             err_fn,
             None,
@@ -111,82 +73,42 @@ pub fn run_audio_engine(synth: Arc<Synthesizer>) -> anyhow::Result<Stream> {
     Ok(stream) // Return the stream
 }
 
-// --- Generic Audio Callback Function ---
+// --- Generic Audio Callback Function (Refactored) ---
 fn write_data<T>(
     output: &mut [T],
     channels: usize,
-    control: &Arc<Mutex<SynthControl>>,
-    // Oscillators
-    sine_osc: &mut Oscillator<Sine>,
-    square_osc: &mut Oscillator<Square>,
-    saw_osc: &mut Oscillator<Saw>,
-    triangle_osc: &mut Oscillator<Triangle>,
-    // State tracking
-    previous_waveform: &mut ActiveWaveform, // Pass previous waveform state mutably
+    voice_handle: &Arc<Mutex<Voice>>, // Use the Voice handle
 ) where
     T: Sample + FromSample<f32>,
 {
-    if let Ok(locked_control) = control.lock() {
-        let freq = locked_control.frequency;
-        let current_wave = locked_control.waveform; // Renamed for clarity
-        let amp = locked_control.amplitude;
+    // Lock the mutex once per callback if possible for efficiency,
+    // but locking per frame is simpler to start with.
+    // Consider optimizing later if needed.
 
-        // --- Phase Reset Logic ---
-        // Check if the waveform has changed since the last buffer
-        if current_wave != *previous_waveform {
-            // Reset the phase of the *newly selected* oscillator to 0.0
-            match current_wave {
-                ActiveWaveform::Sine => sine_osc.reset_phase(0.0),
-                ActiveWaveform::Square => square_osc.reset_phase(0.0),
-                ActiveWaveform::Saw => saw_osc.reset_phase(0.0),
-                ActiveWaveform::Triangle => triangle_osc.reset_phase(0.0),
-                ActiveWaveform::Silence => {}
-            }
-            // Update the state for the next call
-            *previous_waveform = current_wave;
-            // Optional: Print a message when switching
-            println!("Audio thread: Switched to {:?}, phase reset.", current_wave);
-        }
+    for frame in output.chunks_mut(channels) {
+        // Lock the mutex to get access to the voice state for this frame
+        if let Ok(mut voice_guard) = voice_handle.lock() {
+            // Get the next sample value directly from the voice.
+            // This now handles oscillator selection, frequency, and envelope.
+            let value = voice_guard.next_sample();
 
-        // Update frequency for the *active* oscillator
-        match current_wave {
-            ActiveWaveform::Sine => sine_osc.set_frequency(freq),
-            ActiveWaveform::Square => square_osc.set_frequency(freq),
-            ActiveWaveform::Saw => saw_osc.set_frequency(freq),
-            ActiveWaveform::Triangle => triangle_osc.set_frequency(freq),
-            ActiveWaveform::Silence => {}
-        }
+            // Drop the lock as soon as we have the value for this frame
+            drop(voice_guard);
 
-        // Drop lock before sample generation loop
-        drop(locked_control);
-
-        // Generate samples for the buffer
-        for frame in output.chunks_mut(channels) {
-            // Call next_sample directly on the selected oscillator
-            let value = match current_wave {
-                // Use current_wave here
-                ActiveWaveform::Sine => sine_osc.next_sample(),
-                ActiveWaveform::Square => square_osc.next_sample(),
-                ActiveWaveform::Saw => saw_osc.next_sample(),
-                ActiveWaveform::Triangle => triangle_osc.next_sample(),
-                ActiveWaveform::Silence => 0.0,
-            } * amp; // Apply amplitude
-
-            // Convert to the target sample format T
+            // Convert to the target sample format T and write to output channels
             let sample: T = T::from_sample(value);
             for dest_sample in frame.iter_mut() {
                 *dest_sample = sample;
             }
-        }
-    } else {
-        // Mutex is poisoned
-        eprintln!("Audio thread: Mutex poisoned, outputting silence.");
-        // Fill buffer with silence
-        for frame in output.chunks_mut(channels) {
+        } else {
+            // Mutex is poisoned - fill buffer with silence
+            eprintln!("Audio thread: Voice mutex poisoned, outputting silence.");
             let sample: T = T::from_sample(0.0f32);
             for dest_sample in frame.iter_mut() {
                 *dest_sample = sample;
             }
+            // Optional: break the loop if mutex is poisoned?
+            // break;
         }
     }
 }

--- a/audio_backend/src/envelope/mod.rs
+++ b/audio_backend/src/envelope/mod.rs
@@ -1,0 +1,392 @@
+const MIN_LEVEL: f32 = 0.0001; // Threshold to consider the envelope finished in release state
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum EnvelopeState {
+    Idle,
+    Attack,
+    Decay,
+    Sustain,
+    Release,
+}
+
+#[derive(Debug, Clone)]
+pub struct AdsrEnvelope {
+    state: EnvelopeState,
+    attack_rate: f32,
+    decay_rate: f32,
+    release_rate: f32,
+    sustain_level: f32,
+    current_level: f32,
+    // Keep sample_rate if needed for more complex calculations later,
+    // but rates are pre-calculated now.
+    // sample_rate: f32,
+}
+
+impl AdsrEnvelope {
+    /// Creates a new ADSR envelope generator.
+    ///
+    /// # Arguments
+    ///
+    /// * `sample_rate` - The audio sample rate in Hz.
+    /// * `attack_secs` - The attack time in seconds.
+    /// * `decay_secs` - The decay time in seconds.
+    /// * `sustain_level` - The sustain level (0.0 to 1.0).
+    /// * `release_secs` - The release time in seconds.
+    pub fn new(
+        sample_rate: f32,
+        attack_secs: f32,
+        decay_secs: f32,
+        sustain_level: f32,
+        release_secs: f32,
+    ) -> Self {
+        // Clamp sustain level
+        let sustain_level = sustain_level.max(0.0).min(1.0);
+
+        // Calculate rates based on time to reach target level (1.0 for attack, sustain_level for decay/release)
+        // Rate = delta_level / (time_secs * sample_rate)
+        // Handle zero times to avoid division by zero - use a very small time instead for near-instantaneous change
+        let calculate_rate = |time_secs: f32, delta_level: f32| {
+            if time_secs <= 0.0 {
+                // Effectively infinite rate for instant change
+                f32::INFINITY
+            } else {
+                delta_level / (time_secs * sample_rate)
+            }
+        };
+
+        // Attack goes from 0 to 1
+        let attack_rate = calculate_rate(attack_secs, 1.0);
+        // Decay goes from 1 to sustain_level
+        let decay_rate = calculate_rate(decay_secs, 1.0 - sustain_level);
+        // Release goes from current level (assumed sustain_level for calculation) to 0
+        let release_rate = calculate_rate(release_secs, sustain_level.max(MIN_LEVEL)); // Use sustain level for rate calc
+
+        AdsrEnvelope {
+            state: EnvelopeState::Idle,
+            attack_rate,
+            decay_rate,
+            release_rate,
+            sustain_level,
+            current_level: 0.0,
+            // sample_rate,
+        }
+    }
+
+    /// Processes one sample of the envelope, updating its state and level.
+    /// Returns the current envelope level *before* the update for this sample.
+    pub fn process(&mut self) -> f32 {
+        let output_level = self.current_level;
+
+        match self.state {
+            EnvelopeState::Idle => {
+                // Do nothing, level stays at 0 (or near-zero after release)
+            }
+            EnvelopeState::Attack => {
+                if self.attack_rate.is_infinite() {
+                    self.current_level = 1.0; // Instant attack
+                } else {
+                    self.current_level += self.attack_rate;
+                }
+
+                if self.current_level >= 1.0 {
+                    self.current_level = 1.0;
+                    self.state = EnvelopeState::Decay;
+                }
+            }
+            EnvelopeState::Decay => {
+                 if self.decay_rate.is_infinite() || self.sustain_level >= 1.0 {
+                    self.current_level = self.sustain_level; // Instant decay or sustain is at max
+                 } else {
+                    self.current_level -= self.decay_rate;
+                 }
+
+
+                if self.current_level <= self.sustain_level {
+                    self.current_level = self.sustain_level;
+                    // Only transition to Sustain if sustain level is positive
+                    if self.sustain_level > MIN_LEVEL {
+                         self.state = EnvelopeState::Sustain;
+                    } else {
+                        // If sustain is zero, go directly to idle after decay?
+                        // Or should it wait for release? Let's assume it waits.
+                        // If sustain is effectively zero, decay finishes, stay here until release.
+                        // Alternative: self.state = EnvelopeState::Idle;
+                         self.state = EnvelopeState::Sustain; // Treat as sustain phase even at zero level
+                    }
+                }
+            }
+            EnvelopeState::Sustain => {
+                // Level remains at sustain_level
+                // State change happens on release() call
+                self.current_level = self.sustain_level;
+            }
+            EnvelopeState::Release => {
+                if self.release_rate.is_infinite() {
+                    self.current_level = 0.0; // Instant release
+                } else {
+                    // Use the rate calculated based on sustain level, but apply it proportionally
+                    // Rate = delta_level / samples => delta_level = Rate * samples
+                    // We want to decrease by release_rate (which assumes starting from sustain_level)
+                    // A simple linear decrease:
+                     self.current_level -= self.release_rate;
+                    // Alternative exponential decay (more natural):
+                    // self.current_level *= self.release_multiplier; // requires precalculating multiplier
+                }
+
+
+                if self.current_level <= MIN_LEVEL {
+                    self.current_level = 0.0; // Clamp to zero
+                    self.state = EnvelopeState::Idle;
+                }
+            }
+        }
+        output_level
+    }
+
+    /// Triggers the envelope, starting the Attack phase.
+    pub fn trigger(&mut self) {
+        if self.state == EnvelopeState::Idle || self.state == EnvelopeState::Release {
+             self.current_level = 0.0; // Reset level only if starting from idle/release
+        }
+        // Allow re-triggering from any state? Yes, common behavior.
+        self.state = EnvelopeState::Attack;
+
+    }
+
+    /// Starts the Release phase of the envelope.
+    pub fn release(&mut self) {
+        // Can only release if not already idle
+        if self.state != EnvelopeState::Idle {
+            self.state = EnvelopeState::Release;
+        }
+    }
+
+    /// Returns `true` if the envelope is currently active (not Idle).
+    pub fn is_active(&self) -> bool {
+        self.state != EnvelopeState::Idle
+    }
+
+    /// Gets the current state of the envelope.
+    pub fn get_state(&self) -> EnvelopeState {
+        self.state
+    }
+
+    /// Gets the current output level of the envelope.
+    pub fn get_level(&self) -> f32 {
+        self.current_level
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_RATE: f32 = 44100.0;
+    const TOLERANCE: f32 = 0.001; // Tolerance for floating point comparisons
+
+    #[test]
+    fn test_adsr_creation_and_initial_state() {
+        let adsr = AdsrEnvelope::new(SAMPLE_RATE, 0.1, 0.2, 0.5, 0.3);
+        assert_eq!(adsr.get_state(), EnvelopeState::Idle);
+        assert_eq!(adsr.get_level(), 0.0);
+        assert!(!adsr.is_active());
+        assert!(adsr.attack_rate > 0.0 && adsr.attack_rate.is_finite());
+        assert!(adsr.decay_rate > 0.0 && adsr.decay_rate.is_finite());
+        assert!(adsr.release_rate > 0.0 && adsr.release_rate.is_finite());
+        assert_eq!(adsr.sustain_level, 0.5);
+    }
+
+     #[test]
+    fn test_instant_attack() {
+        let mut adsr = AdsrEnvelope::new(SAMPLE_RATE, 0.0, 0.1, 0.5, 0.1);
+        adsr.trigger();
+        assert_eq!(adsr.get_state(), EnvelopeState::Attack);
+        let level = adsr.process(); // Process first sample
+        assert_eq!(level, 0.0); // Returns level *before* update
+        assert_eq!(adsr.get_level(), 1.0); // Level should be 1.0 immediately
+        assert_eq!(adsr.get_state(), EnvelopeState::Decay); // Should transition to Decay
+    }
+
+    #[test]
+    fn test_trigger_attack_decay_sustain() {
+        let attack_secs = 0.1;
+        let decay_secs = 0.2;
+        let sustain_level = 0.5;
+        let mut adsr = AdsrEnvelope::new(SAMPLE_RATE, attack_secs, decay_secs, sustain_level, 0.3);
+
+        adsr.trigger();
+        assert_eq!(adsr.get_state(), EnvelopeState::Attack);
+        assert!(adsr.is_active());
+
+        // Simulate time passing through attack phase
+        let attack_samples = (attack_secs * SAMPLE_RATE).ceil() as usize;
+        let mut last_level = 0.0;
+        for i in 0..=attack_samples { // Use <= to ensure transition
+            let current_output = adsr.process();
+             if i > 0 { // Skip check on first sample where output is 0 but level might jump
+                 assert!(current_output >= last_level - TOLERANCE, "Attack level decreased");
+             }
+            last_level = adsr.get_level(); // Check internal level after process
+            if adsr.get_state() == EnvelopeState::Decay {
+                break; // Transitioned
+            }
+        }
+        assert_eq!(adsr.get_state(), EnvelopeState::Decay, "Should be in Decay state");
+        assert!((adsr.get_level() - 1.0).abs() < TOLERANCE, "Level should be near 1.0 at end of attack");
+
+
+        // Simulate time passing through decay phase
+        let decay_samples = (decay_secs * SAMPLE_RATE).ceil() as usize;
+        last_level = adsr.get_level();
+         for i in 0..=decay_samples { // Use <= to ensure transition
+            let current_output = adsr.process();
+             if i > 0 && adsr.get_state() == EnvelopeState::Decay { // Only check decrease during decay
+                 assert!(current_output <= last_level + TOLERANCE, "Decay level increased");
+             }
+            last_level = adsr.get_level();
+            if adsr.get_state() == EnvelopeState::Sustain {
+                break; // Transitioned
+            }
+        }
+        assert_eq!(adsr.get_state(), EnvelopeState::Sustain, "Should be in Sustain state");
+        assert!((adsr.get_level() - sustain_level).abs() < TOLERANCE, "Level should be near sustain_level");
+
+        // Check sustain phase
+        let sustain_output1 = adsr.process();
+        let sustain_output2 = adsr.process();
+        assert_eq!(adsr.get_state(), EnvelopeState::Sustain);
+        assert!((sustain_output1 - sustain_level).abs() < TOLERANCE);
+        assert!((sustain_output2 - sustain_level).abs() < TOLERANCE);
+        assert!((adsr.get_level() - sustain_level).abs() < TOLERANCE);
+    }
+
+    #[test]
+    fn test_release_and_idle() {
+        let sustain_level = 0.6;
+        let release_secs = 0.1;
+        let mut adsr = AdsrEnvelope::new(SAMPLE_RATE, 0.01, 0.02, sustain_level, release_secs);
+
+        // Get to sustain state quickly
+        adsr.trigger();
+        // Simulate enough time to reach sustain
+        for _ in 0..((0.01 + 0.02) * SAMPLE_RATE).ceil() as usize + 10 {
+            adsr.process();
+            if adsr.get_state() == EnvelopeState::Sustain { break; }
+        }
+        assert_eq!(adsr.get_state(), EnvelopeState::Sustain);
+        assert!((adsr.get_level() - sustain_level).abs() < TOLERANCE);
+
+        // Release
+        adsr.release();
+        assert_eq!(adsr.get_state(), EnvelopeState::Release);
+        assert!(adsr.is_active());
+
+        // Simulate time passing through release phase
+        let release_samples = (release_secs * SAMPLE_RATE).ceil() as usize;
+        let mut last_level = adsr.get_level();
+        for i in 0..=release_samples + 1 { // Add extra sample to ensure transition if needed
+             let current_output = adsr.process();
+             if i > 0 && adsr.get_state() == EnvelopeState::Release {
+                 assert!(current_output <= last_level + TOLERANCE, "Release level increased");
+             }
+            last_level = adsr.get_level();
+            if !adsr.is_active() { // Check using is_active which means state is Idle
+                break;
+            }
+        }
+
+        assert_eq!(adsr.get_state(), EnvelopeState::Idle, "Should be in Idle state after release");
+        assert!(!adsr.is_active());
+        assert!(adsr.get_level() < MIN_LEVEL, "Level should be near zero"); // Check internal level is near zero
+    }
+
+     #[test]
+    fn test_retrigger() {
+        let mut adsr = AdsrEnvelope::new(SAMPLE_RATE, 0.1, 0.1, 0.5, 0.1);
+        adsr.trigger();
+        // Process part way through attack
+        for _ in 0..((0.1 * SAMPLE_RATE) / 2.0) as usize {
+            adsr.process();
+        }
+        let level_before_retrigger = adsr.get_level();
+        assert!(level_before_retrigger > 0.0 && level_before_retrigger < 1.0);
+        assert_eq!(adsr.get_state(), EnvelopeState::Attack);
+
+        // Retrigger
+        adsr.trigger();
+        assert_eq!(adsr.get_state(), EnvelopeState::Attack);
+        // Level should NOT reset to 0 when retriggering from attack/decay/sustain
+        assert!((adsr.get_level() - level_before_retrigger).abs() < TOLERANCE, "Level should not reset on retrigger from attack");
+
+        // Let it decay a bit
+         for _ in 0..((0.1 + 0.1) * SAMPLE_RATE) as usize { // Pass attack + decay time
+            adsr.process();
+             if adsr.get_state() == EnvelopeState::Sustain { break; }
+        }
+         assert_eq!(adsr.get_state(), EnvelopeState::Sustain);
+         let level_in_sustain = adsr.get_level();
+
+         // Retrigger from sustain
+         adsr.trigger();
+         assert_eq!(adsr.get_state(), EnvelopeState::Attack);
+         assert!((adsr.get_level() - level_in_sustain).abs() < TOLERANCE, "Level should not reset on retrigger from sustain");
+
+
+    }
+
+     #[test]
+    fn test_release_from_attack() {
+        let mut adsr = AdsrEnvelope::new(SAMPLE_RATE, 0.1, 0.1, 0.5, 0.1);
+        adsr.trigger();
+        // Process part way through attack
+        for _ in 0..((0.1 * SAMPLE_RATE) / 3.0) as usize {
+            adsr.process();
+        }
+        assert_eq!(adsr.get_state(), EnvelopeState::Attack);
+        let level_before_release = adsr.get_level();
+        assert!(level_before_release > 0.0 && level_before_release < 1.0);
+
+        adsr.release();
+        assert_eq!(adsr.get_state(), EnvelopeState::Release);
+        assert!((adsr.get_level() - level_before_release).abs() < TOLERANCE, "Level should not change immediately on release call");
+
+        // Process one step
+        let output = adsr.process();
+        assert!((output - level_before_release).abs() < TOLERANCE); // Output is level *before* update
+        assert!(adsr.get_level() < level_before_release); // Level should decrease
+    }
+
+     #[test]
+    fn test_zero_sustain() {
+        let mut adsr = AdsrEnvelope::new(SAMPLE_RATE, 0.01, 0.02, 0.0, 0.03);
+        adsr.trigger();
+
+        // Process through attack and decay
+        let total_samples = ((0.01 + 0.02) * SAMPLE_RATE).ceil() as usize + 5;
+        for _ in 0..total_samples {
+            adsr.process();
+            // It should end up in Sustain state, even if level is 0
+            if adsr.get_state() == EnvelopeState::Sustain {
+                break;
+            }
+        }
+        assert_eq!(adsr.get_state(), EnvelopeState::Sustain);
+        assert!(adsr.get_level() < MIN_LEVEL); // Level should be near zero
+
+        // Stay in sustain (at zero level)
+        adsr.process();
+        assert_eq!(adsr.get_state(), EnvelopeState::Sustain);
+        assert!(adsr.get_level() < MIN_LEVEL);
+
+        // Release should transition to release and then quickly to idle
+        adsr.release();
+        assert_eq!(adsr.get_state(), EnvelopeState::Release);
+        adsr.process(); // Process one step in release
+        // Since level is already ~0, it should immediately go idle
+        assert_eq!(adsr.get_state(), EnvelopeState::Idle);
+        assert!(adsr.get_level() < MIN_LEVEL);
+
+    }
+}
+

--- a/audio_backend/src/lib.rs
+++ b/audio_backend/src/lib.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use synths::synthesizer::Synthesizer;
 
 pub mod devices;
-pub mod synths;
-pub mod envelope; // Add the new module
+pub mod envelope;
+pub mod synths; // Add the new module
 
 type Result<T> = anyhow::Result<T, anyhow::Error>;
 

--- a/audio_backend/src/lib.rs
+++ b/audio_backend/src/lib.rs
@@ -4,6 +4,7 @@ use synths::synthesizer::Synthesizer;
 
 pub mod devices;
 pub mod synths;
+pub mod envelope; // Add the new module
 
 type Result<T> = anyhow::Result<T, anyhow::Error>;
 

--- a/audio_backend/src/synths/synthesizer.rs
+++ b/audio_backend/src/synths/synthesizer.rs
@@ -48,6 +48,20 @@ impl Voice {
 
     pub fn set_waveform(&mut self, waveform: ActiveWaveform) {
         self.active_waveform = waveform;
+        match self.active_waveform {
+            ActiveWaveform::Sine => {
+                self.sine_osc.reset_phase(0.0);
+            }
+            ActiveWaveform::Square => {
+                self.square_osc.reset_phase(0.0);
+            }
+            ActiveWaveform::Saw => {
+                self.saw_osc.reset_phase(0.0);
+            }
+            ActiveWaveform::Triangle => {
+                self.triangle_osc.reset_phase(0.0);
+            }
+        }
     }
 
     pub fn note_on(&mut self, freq: f32) {

--- a/audio_backend/src/synths/synthesizer.rs
+++ b/audio_backend/src/synths/synthesizer.rs
@@ -1,3 +1,5 @@
+use crate::envelope::AdsrEnvelope;
+use crate::synths::oscillator::{Oscillator, Saw, Sine, Square, Triangle};
 use std::sync::{Arc, Mutex};
 
 // --- Enum to Select Active Waveform ---
@@ -7,83 +9,337 @@ pub enum ActiveWaveform {
     Square,
     Saw,
     Triangle,
-    Silence,
 }
 
-// --- Struct for Shared Synthesizer Control State ---
+// Define the Voice struct
+#[derive(Debug, Clone)] // Clone might be useful, review if needed later
+pub struct Voice {
+    sine_osc: Oscillator<Sine>,
+    square_osc: Oscillator<Square>,
+    saw_osc: Oscillator<Saw>,
+    triangle_osc: Oscillator<Triangle>,
+    envelope: AdsrEnvelope,
+    current_frequency: f32,
+    active_waveform: ActiveWaveform,
+    sample_rate: f32, // Store sample rate for oscillator frequency updates
+}
+
+impl Voice {
+    pub fn new(sample_rate: f32) -> Self {
+        // Default ADSR values (can be configured later)
+        let envelope = AdsrEnvelope::new(sample_rate, 0.01, 0.1, 0.8, 0.2);
+
+        Voice {
+            sine_osc: Oscillator::new(sample_rate, 0.0),
+            square_osc: Oscillator::new(sample_rate, 0.0),
+            saw_osc: Oscillator::new(sample_rate, 0.0),
+            triangle_osc: Oscillator::new(sample_rate, 0.0),
+            envelope,
+            current_frequency: 440.0, // Default A4
+            active_waveform: ActiveWaveform::Sine,
+            sample_rate,
+        }
+    }
+
+    pub fn set_frequency(&mut self, freq: f32) {
+        self.current_frequency = freq;
+        // No need to update oscillators here, will be done in next_sample
+    }
+
+    pub fn set_waveform(&mut self, waveform: ActiveWaveform) {
+        self.active_waveform = waveform;
+    }
+
+    pub fn note_on(&mut self, freq: f32) {
+        self.current_frequency = freq;
+        self.envelope.trigger();
+    }
+
+    pub fn note_off(&mut self) {
+        self.envelope.release();
+    }
+
+    // Calculate the next sample for this voice
+    pub fn next_sample(&mut self) -> f32 {
+        if !self.envelope.is_active() {
+            return 0.0;
+        }
+
+        let envelope_level = self.envelope.process();
+
+        let osc_sample = match self.active_waveform {
+            ActiveWaveform::Sine => {
+                self.sine_osc.set_frequency(self.current_frequency);
+                self.sine_osc.next_sample()
+            }
+            ActiveWaveform::Square => {
+                self.square_osc.set_frequency(self.current_frequency);
+                self.square_osc.next_sample()
+            }
+            ActiveWaveform::Saw => {
+                self.saw_osc.set_frequency(self.current_frequency);
+                self.saw_osc.next_sample()
+            }
+            ActiveWaveform::Triangle => {
+                self.triangle_osc.set_frequency(self.current_frequency);
+                self.triangle_osc.next_sample()
+            }
+        };
+
+        osc_sample * envelope_level
+    }
+
+    // Method to check if the voice is active (useful for polyphony later)
+    pub fn is_active(&self) -> bool {
+        self.envelope.is_active()
+    }
+
+    // Method to configure ADSR parameters
+    pub fn set_adsr(&mut self, attack: f32, decay: f32, sustain: f32, release: f32) {
+        self.envelope = AdsrEnvelope::new(self.sample_rate, attack, decay, sustain, release);
+    }
+
+    // Helper for tests
+    #[cfg(test)]
+    fn get_envelope_state(&self) -> crate::envelope::EnvelopeState {
+        self.envelope.get_state()
+    }
+}
+
+// --- Synthesizer Struct (Refactored) ---
+
+// Remove the old SynthControl struct if it exists
+
 #[derive(Debug, Clone)]
-pub struct SynthControl {
-    pub frequency: f32,
-    pub waveform: ActiveWaveform,
-    pub amplitude: f32, // Added amplitude control
+pub struct Synthesizer {
+    voice: Arc<Mutex<Voice>>, // Use Arc<Mutex> for thread safety
+    sample_rate: f32,
 }
 
-#[derive(Clone)] // Clone is cheap due to Arc
-pub struct Synthesizer {
-    pub control: Arc<Mutex<SynthControl>>,
-}
+const DEFAULT_SAMPLE_RATE: f32 = 44100.0; // Default sample rate constant
 
 impl Default for Synthesizer {
     fn default() -> Self {
-        Synthesizer::new(0.0, ActiveWaveform::Silence, 0.0) // Default to A4 note
+        Synthesizer::new(DEFAULT_SAMPLE_RATE)
     }
 }
 
 impl Synthesizer {
-    /// Creates a new Synthesizer controller.
-    pub fn new(
-        initial_frequency: f32,
-        initial_waveform: ActiveWaveform,
-        initial_amplitude: f32,
-    ) -> Self {
+    pub fn new(sample_rate: f32) -> Self {
         Synthesizer {
-            control: Arc::new(Mutex::new(SynthControl {
-                frequency: initial_frequency,
-                waveform: initial_waveform,
-                amplitude: initial_amplitude.clamp(0.0, 1.0), // Clamp amplitude
-            })),
+            voice: Arc::new(Mutex::new(Voice::new(sample_rate))),
+            sample_rate,
         }
     }
 
-    /// Sets the synthesizer's frequency.
-    pub fn set_frequency(&self, frequency: f32) {
-        // Lock, update, drop lock automatically
-        if let Ok(mut control) = self.control.lock() {
-            control.frequency = frequency.max(0.0);
+    // --- Methods to control the voice ---
+
+    pub fn set_frequency(&self, freq: f32) {
+        if let Ok(mut voice) = self.voice.lock() {
+            voice.set_frequency(freq);
         } else {
-            eprintln!("Error setting frequency: Mutex poisoned");
+            eprintln!("Error locking voice mutex in set_frequency");
         }
     }
 
-    /// Sets the synthesizer's active waveform.
     pub fn set_waveform(&self, waveform: ActiveWaveform) {
-        if let Ok(mut control) = self.control.lock() {
-            control.waveform = waveform;
+        if let Ok(mut voice) = self.voice.lock() {
+            voice.set_waveform(waveform);
         } else {
-            eprintln!("Error setting waveform: Mutex poisoned");
+            eprintln!("Error locking voice mutex in set_waveform");
         }
     }
 
-    /// Sets the synthesizer's amplitude (clamped between 0.0 and 1.0).
-    pub fn set_amplitude(&self, amplitude: f32) {
-        if let Ok(mut control) = self.control.lock() {
-            control.amplitude = amplitude.clamp(0.0, 1.0);
+    pub fn set_adsr(&self, attack: f32, decay: f32, sustain: f32, release: f32) {
+        if let Ok(mut voice) = self.voice.lock() {
+            voice.set_adsr(attack, decay, sustain, release);
         } else {
-            eprintln!("Error setting amplitude: Mutex poisoned");
+            eprintln!("Error locking voice mutex in set_adsr");
         }
     }
 
-    // Internal helper to get a clone of the control Arc for the audio thread
-    pub fn get_control_clone(&self) -> Arc<Mutex<SynthControl>> {
-        Arc::clone(&self.control)
+    pub fn note_on(&self, freq: f32) {
+        if let Ok(mut voice) = self.voice.lock() {
+            voice.note_on(freq);
+        } else {
+            eprintln!("Error locking voice mutex in note_on");
+        }
     }
 
-    // Helper to get the initial waveform, needed for the audio thread state
-    pub fn get_initial_waveform(&self) -> ActiveWaveform {
-        // We can ignore mutex poisoning here, as it's just for initialization
-        self.control
-            .lock()
-            .map(|c| c.waveform)
-            .unwrap_or(ActiveWaveform::Sine)
+    pub fn note_off(&self) {
+        if let Ok(mut voice) = self.voice.lock() {
+            voice.note_off();
+        } else {
+            eprintln!("Error locking voice mutex in note_off");
+        }
+    }
+
+    // Method needed by the audio callback to get access to the voice
+    // Cloning Arc is cheap (increases reference count)
+    pub fn get_voice_handle(&self) -> Arc<Mutex<Voice>> {
+        self.voice.clone()
+    }
+
+    pub fn get_sample_rate(&self) -> f32 {
+        self.sample_rate
+    }
+
+    // Helper for tests
+    #[cfg(test)]
+    fn get_voice_frequency(&self) -> f32 {
+        self.voice.lock().unwrap().current_frequency
+    }
+    #[cfg(test)]
+    fn get_voice_waveform(&self) -> ActiveWaveform {
+        self.voice.lock().unwrap().active_waveform
+    }
+    #[cfg(test)]
+    fn get_voice_envelope_state(&self) -> crate::envelope::EnvelopeState {
+        self.voice.lock().unwrap().get_envelope_state()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::EnvelopeState; // Import EnvelopeState for comparison
+
+    const TEST_SAMPLE_RATE: f32 = 44100.0;
+    const TEST_FREQ: f32 = 440.0; // A4
+    const TOLERANCE: f32 = 0.001;
+
+    fn process_voice_for_samples(voice: &mut Voice, num_samples: usize) {
+        for _ in 0..num_samples {
+            voice.next_sample();
+        }
+    }
+
+    fn process_voice_for_secs(voice: &mut Voice, seconds: f32) {
+        let num_samples = (seconds * voice.sample_rate).ceil() as usize;
+        process_voice_for_samples(voice, num_samples);
+    }
+
+    #[test]
+    fn voice_creation() {
+        let voice = Voice::new(TEST_SAMPLE_RATE);
+        assert_eq!(voice.current_frequency, 440.0);
+        assert_eq!(voice.active_waveform, ActiveWaveform::Sine);
+        assert!(!voice.is_active()); // Starts inactive
+        assert_eq!(voice.sample_rate, TEST_SAMPLE_RATE);
+    }
+
+    #[test]
+    fn voice_note_on_off() {
+        let mut voice = Voice::new(TEST_SAMPLE_RATE);
+        assert!(!voice.is_active());
+        assert_eq!(voice.get_envelope_state(), EnvelopeState::Idle);
+
+        voice.note_on(TEST_FREQ);
+        assert!(voice.is_active());
+        assert_eq!(voice.current_frequency, TEST_FREQ);
+        assert_eq!(voice.get_envelope_state(), EnvelopeState::Attack);
+
+        // Process a bit (less than attack time)
+        process_voice_for_samples(&mut voice, 100);
+        assert!(voice.is_active());
+        assert_ne!(voice.get_envelope_state(), EnvelopeState::Idle); // Should be Attack or Decay
+
+        voice.note_off();
+        assert!(voice.is_active()); // Still active during release
+        assert_eq!(voice.get_envelope_state(), EnvelopeState::Release);
+
+        // Process enough time for release to finish (default release is 0.2s)
+        process_voice_for_secs(&mut voice, 0.3);
+        assert!(!voice.is_active());
+        assert_eq!(voice.get_envelope_state(), EnvelopeState::Idle);
+    }
+
+    #[test]
+    fn voice_waveform_change() {
+        let mut voice = Voice::new(TEST_SAMPLE_RATE);
+        voice.note_on(TEST_FREQ);
+        voice.set_waveform(ActiveWaveform::Square);
+        assert_eq!(voice.active_waveform, ActiveWaveform::Square);
+
+        // Process one sample to check if the correct oscillator is used (indirect check)
+        let sample1 = voice.next_sample();
+        // Change waveform and process again
+        voice.set_waveform(ActiveWaveform::Saw);
+        assert_eq!(voice.active_waveform, ActiveWaveform::Saw);
+        let sample2 = voice.next_sample();
+
+        // We expect different waveforms to produce different samples generally
+        // This isn't a perfect test but checks the switch is happening
+        // A more robust test would analyze the output over time
+        assert_ne!(
+            sample1, sample2,
+            "Sample should differ after waveform change"
+        );
+    }
+
+    #[test]
+    fn voice_frequency_change() {
+        let mut voice = Voice::new(TEST_SAMPLE_RATE);
+        voice.note_on(TEST_FREQ);
+        assert_eq!(voice.current_frequency, TEST_FREQ);
+
+        let freq2 = 880.0;
+        voice.set_frequency(freq2);
+        assert_eq!(voice.current_frequency, freq2);
+
+        // Process a sample - frequency update happens inside next_sample
+        voice.next_sample();
+        // Check internal oscillator frequency (requires making osc fields pub(crate) or adding getters)
+        // For now, we assume set_frequency is called correctly within next_sample
+    }
+
+    #[test]
+    fn voice_adsr_change() {
+        let mut voice = Voice::new(TEST_SAMPLE_RATE);
+        // Set very short ADSR
+        voice.set_adsr(0.001, 0.001, 0.1, 0.001);
+        voice.note_on(TEST_FREQ);
+
+        // Should quickly reach sustain level (0.1)
+        process_voice_for_secs(&mut voice, 0.01);
+        assert_eq!(voice.get_envelope_state(), EnvelopeState::Sustain);
+        assert!((voice.envelope.get_level() - 0.1).abs() < TOLERANCE);
+
+        voice.note_off();
+        // Should quickly become idle
+        process_voice_for_secs(&mut voice, 0.01);
+        assert_eq!(voice.get_envelope_state(), EnvelopeState::Idle);
+    }
+
+    #[test]
+    fn synthesizer_controls_voice() {
+        let synth = Synthesizer::new(TEST_SAMPLE_RATE);
+        assert_eq!(synth.get_sample_rate(), TEST_SAMPLE_RATE);
+
+        // Test note on/off via synthesizer
+        assert_eq!(synth.get_voice_envelope_state(), EnvelopeState::Idle);
+        synth.note_on(TEST_FREQ);
+        assert_eq!(synth.get_voice_frequency(), TEST_FREQ);
+        assert_eq!(synth.get_voice_envelope_state(), EnvelopeState::Attack);
+
+        synth.note_off();
+        // Need to process some samples for state to change in underlying envelope
+        // This test only checks the immediate effect of the call on the state flag
+        // A full test would involve running the audio callback simulation
+        assert_eq!(synth.get_voice_envelope_state(), EnvelopeState::Release);
+
+        // Test waveform change
+        synth.set_waveform(ActiveWaveform::Triangle);
+        assert_eq!(synth.get_voice_waveform(), ActiveWaveform::Triangle);
+
+        // Test frequency change
+        let freq2 = 660.0;
+        synth.set_frequency(freq2);
+        assert_eq!(synth.get_voice_frequency(), freq2);
+
+        // Test ADSR change
+        synth.set_adsr(0.1, 0.2, 0.7, 0.3);
+        // We can't easily verify the internal rates without more access,
+        // but we check the call doesn't panic.
     }
 }

--- a/frontend/src/oscillator-control.ts
+++ b/frontend/src/oscillator-control.ts
@@ -2,7 +2,6 @@
 import { invoke } from "@tauri-apps/api/core";
 
 export const waveforms = [
-  { value: "Silence", label: "None" },
   { value: "Sine", label: "Sine" },
   { value: "Square", label: "Square" },
   { value: "Saw", label: "Saw" },


### PR DESCRIPTION
closes #2 
closes #3 

This pull request introduces a significant refactor of the audio synthesizer architecture, replacing the previous control-based design with a new `Voice` abstraction. The changes simplify the audio engine, improve encapsulation, and add support for ADSR (Attack-Decay-Sustain-Release) envelopes. Key updates include the removal of individual oscillator management in the audio thread, the addition of the `Voice` struct, and updates to the frontend to use the new API.

### Synthesizer Refactor:
* Introduced the `Voice` struct to encapsulate oscillators and ADSR envelope processing, replacing the previous `SynthControl` structure. (`audio_backend/src/synths/synthesizer.rs`, [[1]](diffhunk://#diff-f0170b06bd980952b42a9e9e73fa4afe0b82fdf166661eeac7b986dc3e2af1c9R1-R2) [[2]](diffhunk://#diff-f0170b06bd980952b42a9e9e73fa4afe0b82fdf166661eeac7b986dc3e2af1c9L10-R343)
* The `Synthesizer` class now manages a single `Voice` instance wrapped in an `Arc<Mutex>` for thread safety. Methods like `set_frequency`, `set_waveform`, and `note_on` delegate directly to the `Voice`. (`audio_backend/src/synths/synthesizer.rs`, [audio_backend/src/synths/synthesizer.rsL10-R343](diffhunk://#diff-f0170b06bd980952b42a9e9e73fa4afe0b82fdf166661eeac7b986dc3e2af1c9L10-R343))

### Audio Engine Simplification:
* Refactored the `run_audio_engine` function to use the new `Voice` abstraction. Removed individual oscillator initialization and waveform state tracking. (`audio_backend/src/devices/streams.rs`, [audio_backend/src/devices/streams.rsL28-R59](diffhunk://#diff-6118927626c4c1ec59554e317525f3936aaaa2576a47c783f247da4a93ff6ee0L28-R59))
* Updated the audio callback function `write_data` to lock the `Voice` mutex and fetch the next sample, simplifying oscillator and envelope handling. (`audio_backend/src/devices/streams.rs`, [audio_backend/src/devices/streams.rsL114-R111](diffhunk://#diff-6118927626c4c1ec59554e317525f3936aaaa2576a47c783f247da4a93ff6ee0L114-R111))

### Frontend Updates:
* Replaced `set_frequency` and `set_amplitude` calls with `note_on` and `note_off` to align with the new synthesizer API. (`frontend/src-tauri/src/lib.rs`, [frontend/src-tauri/src/lib.rsL28-R35](diffhunk://#diff-4269ce550824adf859d104bff8585f30df789ef78711e1d8d68468b2d81fdad2L28-R35))
* Removed support for the "Silence" waveform, as the `Voice` abstraction now handles silence via the envelope state. (`frontend/src-tauri/src/lib.rs`, [frontend/src-tauri/src/lib.rsL18](diffhunk://#diff-4269ce550824adf859d104bff8585f30df789ef78711e1d8d68468b2d81fdad2L18))

### New Features:
* Added ADSR envelope support to control the amplitude over time for each note. (`audio_backend/src/synths/synthesizer.rs`, [audio_backend/src/synths/synthesizer.rsL10-R343](diffhunk://#diff-f0170b06bd980952b42a9e9e73fa4afe0b82fdf166661eeac7b986dc3e2af1c9L10-R343))
* Created a new `envelope` module to house the `AdsrEnvelope` implementation. (`audio_backend/src/lib.rs`, [audio_backend/src/lib.rsL6-R7](diffhunk://#diff-b1005c54f854616c662aed2c5c23920290f35dd60f0eb065ce576e14f1eb38b7L6-R7))

### Miscellaneous:
* Updated the `Synthesizer` struct to implement the `Default` trait for easier initialization. (`frontend/src-tauri/src/lib.rs`, [frontend/src-tauri/src/lib.rsR45-R48](diffhunk://#diff-4269ce550824adf859d104bff8585f30df789ef78711e1d8d68468b2d81fdad2R45-R48))