### PR TITLE
Added structures and a simple example

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[build]
+# https://rust-lang.github.io/packed_simd/perf-guide/target-feature/rustflags.html#target-cpu
+# as mentioned in the link, this is useful when compiling and running locally. 
+rustflags = ["-C", "target-cpu=native"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "audio_backend_reworked"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "cpal",
+ "env_logger",
+ "log",
+ "ringbuf",
+ "sequencer",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +933,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1023,6 +1050,17 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "ringbuf"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe47b720588c8702e34b5979cb3271a8b1842c7cb6f57408efa70c779363488c"
+dependencies = [
+ "crossbeam-utils",
+ "portable-atomic",
+ "portable-atomic-util",
+]
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,9 @@
 [workspace]
 resolver = "2"
-members = ["audio_backend", "harmony", "sequencer"]
-default-members = ["sequencer"]
+members = ["audio_backend", "audio_backend_reworked", "harmony", "sequencer"]
+# TODO: undo
+# default-members = ["sequencer"]
+default-members = ["audio_backend_reworked"]
 exclude = ["frontend/src-tauri"]
 
 [workspace.dependencies]
@@ -12,6 +14,7 @@ anyhow = "1.0"
 log = "0.4"
 env_logger = "0.10"
 crossbeam = "0.8"
+ringbuf = "0.4.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = "3.14"
@@ -19,3 +22,4 @@ serde_with = "3.14"
 sequencer = { path = "sequencer" }
 harmony = { path = "harmony" }
 audio_backend = { path = "audio_backend" }
+audio_backend_reworked = { path = "audio_backend_reworked" }

--- a/audio_backend_reworked/Cargo.toml
+++ b/audio_backend_reworked/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "audio_backend_reworked"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+cpal = {workspace = true}
+anyhow = {workspace = true}
+log = {workspace = true}
+env_logger = {workspace = true}
+ringbuf = {workspace = true}
+sequencer = {workspace = true}

--- a/audio_backend_reworked/examples/simple_setup.rs
+++ b/audio_backend_reworked/examples/simple_setup.rs
@@ -1,0 +1,28 @@
+use std::thread;
+
+fn main() {
+    // This is a placeholder for the main function.
+    // The actual implementation will depend on how you want to use the BlightAudio API.
+    match &mut audio_backend_reworked::BlightAudio::new() {
+        Ok(audio) => {
+            println!("BlightAudio initialized successfully!");
+            // You can now use `audio` to send commands, etc.
+            audio.send_command(audio_backend_reworked::Command::PlayNote {
+                note: 60,
+                velocity: 127.0,
+            });
+            thread::sleep(std::time::Duration::from_secs(1));
+            audio.send_command(audio_backend_reworked::Command::PlayNote {
+                note: 63,
+                velocity: 127.0,
+            });
+            thread::sleep(std::time::Duration::from_secs(1));
+            audio.send_command(audio_backend_reworked::Command::PlayNote {
+                note: 66,
+                velocity: 127.0,
+            });
+            thread::sleep(std::time::Duration::from_secs(1));
+        }
+        Err(e) => eprintln!("Failed to initialize BlightAudio: {}", e),
+    };
+}

--- a/audio_backend_reworked/src/audio_processor.rs
+++ b/audio_backend_reworked/src/audio_processor.rs
@@ -1,0 +1,58 @@
+use crate::{Command, Synthesizer};
+use ringbuf::{traits::*, HeapCons};
+
+// The core audio processor. Lives exclusively in the RT world.
+pub struct AudioProcessor {
+    command_rx: HeapCons<Command>,
+    synthesizer: Synthesizer,
+    sample_rate: f32,
+    channels: usize,
+    // Pre-allocated, non-interleaved buffers for processing.
+    left_buf: Vec<f32>,
+    right_buf: Vec<f32>,
+}
+
+impl AudioProcessor {
+    pub fn new(command_rx: HeapCons<Command>, sample_rate: f32, channels: usize) -> Self {
+        // A reasonable max buffer size. cpal can change this, but this is a safe upper bound.
+        const MAX_BUFFER_SIZE: usize = 4096;
+        Self {
+            command_rx,
+            synthesizer: Synthesizer::new(sample_rate),
+            sample_rate,
+            channels,
+            left_buf: vec![0.0; MAX_BUFFER_SIZE],
+            right_buf: vec![0.0; MAX_BUFFER_SIZE],
+        }
+    }
+
+    // The main processing function called by the audio driver.
+    pub fn process(&mut self, output_buffer: &mut [f32]) {
+        // 1. Drain the command queue to update state. This is non-blocking.
+        while let Some(command) = self.command_rx.try_pop() {
+            self.synthesizer.handle_command(command);
+        }
+
+        // Calculate the number of frames in this block.
+        let frame_count = output_buffer.len() / self.channels;
+        let (left, right) = (
+            &mut self.left_buf[..frame_count],
+            &mut self.right_buf[..frame_count],
+        );
+
+        // Clear internal buffers.
+        left.fill(0.0);
+        right.fill(0.0);
+
+        // 2. Process audio into our non-interleaved buffers.
+        self.synthesizer.process(left, right);
+
+        // 3. Re-interleave the processed audio back into the output buffer.
+        for (i, frame) in output_buffer.chunks_mut(self.channels).enumerate() {
+            frame[0] = left[i];
+            if self.channels > 1 {
+                frame[1] = right[i];
+            }
+        }
+    }
+}

--- a/audio_backend_reworked/src/blight_audio.rs
+++ b/audio_backend_reworked/src/blight_audio.rs
@@ -1,0 +1,55 @@
+use crate::{AudioProcessor, Command};
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use ringbuf::{traits::*, HeapProd, HeapRb};
+
+// The public-facing API for the audio backend. Lives in the NRT world.
+pub struct BlightAudio {
+    // The producer end of the command queue.
+    command_tx: HeapProd<Command>,
+    // The cpal audio stream. Kept alive to continue playback.
+    _stream: cpal::Stream,
+}
+
+impl BlightAudio {
+    pub fn new() -> Result<Self, anyhow::Error> {
+        let host = cpal::default_host();
+        let device = host
+            .default_output_device()
+            .expect("no output device available");
+        let config = device.default_output_config()?.config();
+        let sample_rate = config.sample_rate.0;
+        let channels = config.channels as usize;
+
+        // Create the SPSC ring buffer for commands using a heap-allocated buffer.
+        let rb = HeapRb::<Command>::new(1024); // Capacity for 1024 commands
+        let (command_tx, command_rx) = rb.split();
+
+        // Create the real-time processor and move it into the audio thread.
+        let mut audio_processor = AudioProcessor::new(command_rx, sample_rate as f32, channels);
+
+        let stream = device.build_output_stream(
+            &config.into(),
+            move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
+                // This closure is the audio callback.
+                audio_processor.process(data);
+            },
+            |err| eprintln!("an error occurred on stream: {}", err),
+            None,
+        )?;
+
+        stream.play()?;
+
+        Ok(BlightAudio {
+            command_tx,
+            _stream: stream,
+        })
+    }
+
+    // Public method to send a command to the audio thread.
+    pub fn send_command(&mut self, command: Command) {
+        if self.command_tx.try_push(command).is_err() {
+            // In a real app, handle this more gracefully (e.g., log, drop command).
+            eprintln!("Command queue is full. Command dropped.");
+        }
+    }
+}

--- a/audio_backend_reworked/src/commands.rs
+++ b/audio_backend_reworked/src/commands.rs
@@ -1,0 +1,6 @@
+pub enum Command {
+    PlayNote { note: u8, velocity: f32 },
+    StopNote { note: u8 },
+    SetParameter { param: String, value: f32 },
+    // Add more commands as needed.
+}

--- a/audio_backend_reworked/src/lib.rs
+++ b/audio_backend_reworked/src/lib.rs
@@ -1,0 +1,9 @@
+mod audio_processor;
+mod blight_audio;
+mod commands;
+mod synth;
+
+pub(crate) use audio_processor::*;
+pub use blight_audio::*;
+pub use commands::*;
+pub(crate) use synth::*;

--- a/audio_backend_reworked/src/synth/mod.rs
+++ b/audio_backend_reworked/src/synth/mod.rs
@@ -1,0 +1,3 @@
+mod synthesizer;
+
+pub use synthesizer::*;

--- a/audio_backend_reworked/src/synth/synthesizer.rs
+++ b/audio_backend_reworked/src/synth/synthesizer.rs
@@ -1,0 +1,66 @@
+use crate::Command;
+
+pub struct Synthesizer {
+    pub sample_rate: f32,
+    // Add more fields as needed for synthesizer state.
+    oscillator: TestOscillator,
+}
+
+struct TestOscillator {
+    sample_rate: f32,
+    frequency: f32,
+    phase: f32,
+}
+
+impl TestOscillator {
+    pub fn new(sample_rate: f32) -> Self {
+        Self {
+            sample_rate,
+            frequency: 0.0, // Default frequency
+            phase: 0.0,     // Initial phase
+        }
+    }
+
+    pub fn next_sample(&mut self) -> f32 {
+        let sample = (self.phase * std::f32::consts::TAU).sin();
+        self.phase += self.frequency / self.sample_rate;
+        if self.phase >= 1.0 {
+            self.phase -= 1.0;
+        }
+        sample
+    }
+}
+
+impl Synthesizer {
+    pub fn new(sample_rate: f32) -> Self {
+        let oscillator = TestOscillator::new(sample_rate);
+        Self {
+            sample_rate,
+            oscillator,
+        }
+    }
+
+    pub fn handle_command(&mut self, command: Command) {
+        match command {
+            Command::PlayNote { note, velocity } => {
+                // midi note translation should be extracted.
+                self.oscillator.frequency = 440.0 * 2f32.powf((note as f32 - 69.0) / 12.0);
+            }
+            Command::StopNote { note } => {
+                // Handle stopping a note.
+            }
+            Command::SetParameter { param, value } => {
+                // Handle setting a parameter.
+            }
+        }
+    }
+
+    pub fn process(&mut self, left_buf: &mut [f32], right_buf: &mut [f32]) {
+        // Process audio and fill the output buffer.
+        for (left, right) in left_buf.iter_mut().zip(right_buf.iter_mut()) {
+            let sample = self.oscillator.next_sample();
+            *left = sample;
+            *right = sample;
+        }
+    }
+}


### PR DESCRIPTION
Closes #28 

- Adding `BlightAudio` and `AudioProcessor` structs to establish clear separation between non-realtime (NRT) and realtime (RT) division.
- Added an example to verify audio production with a simple `TestOscilator`